### PR TITLE
--burn_mode bugfixes, update attribution

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.3
+* `--burn_mode`
+  * Fixed --burn_mode bug causing false positive error message
+  * Added message when using --burn_mode while in Burn Mode
+* Housekeeping
+  * Added 0.1.0 to Changelog
+  * Updated CLI attribution message, added Car-Thing-Hax-Community name/repo link and specified using fork from bishopdynamics in cli output
+
+## 0.1.0 [f371ff7](https://github.com/bishopdynamics/superbird-tool/tree/f371ff715ee4b0ba4f689d9785a7513731242d38)
+* Latest @bishopdynamics release, no official changelog available
+
 ## 0.0.8
 * fix rare divide-by-zero case when reading or writing partitions
 * tweaked how experimental `make-binary.sh` works

--- a/superbird_device.py
+++ b/superbird_device.py
@@ -74,7 +74,9 @@ def find_device(silent:bool=False):
         found_devices = usb.core.find(idVendor=0x1b8e, idProduct=0xc003)
         if found_devices is not None:
             dev_product = found_devices[0].device.product
-            if dev_product is None:
+            # I don't understand it, just documenting it and fixing the bug.
+            # --enter_burn mode somehow has dev_product set to M8-CHIP, --find_device has dev_product be None
+            if dev_product is None or dev_product == "M8-CHIP": 
                 if not silent:
                     print('Found device booted in USB Burn Mode (ready for commands)')
                 return 'usb-burn'

--- a/superbird_device.py
+++ b/superbird_device.py
@@ -75,7 +75,7 @@ def find_device(silent:bool=False):
         if found_devices is not None:
             dev_product = found_devices[0].device.product
             # I don't understand it, just documenting it and fixing the bug.
-            # --enter_burn mode somehow has dev_product set to M8-CHIP, --find_device has dev_product be None
+            # --burn_mode somehow has dev_product set to M8-CHIP, --find_device has dev_product be None
             if dev_product is None or dev_product == "M8-CHIP": 
                 if not silent:
                     print('Found device booted in USB Burn Mode (ready for commands)')

--- a/superbird_tool.py
+++ b/superbird_tool.py
@@ -19,7 +19,7 @@ from uboot_env import read_environ
 from superbird_device import SuperbirdDevice
 from superbird_device import find_device, check_device_mode, enter_burn_mode
 
-VERSION = '0.1.0'
+VERSION = '0.1.3'
 
 # this method chosen specifically because it works correctly when bundled using nuitka --onefile
 IMAGES_PATH = Path(os.path.dirname(__file__)).joinpath('images')
@@ -63,8 +63,9 @@ def rename_parts(folderpath):
             continue
 
 if __name__ == '__main__':
-    print(f'Spotify Car Thing (superbird) toolkit, v{VERSION}, by bishopdynamics')
-    print('     https://github.com/bishopdynamics/superbird-tool')
+    print(f'Spotify Car Thing (superbird) toolkit, v{VERSION}, by Car-Thing-Hax-Community')
+    print('     https://github.com/Car-Thing-Hax-Community/superbird-tool   ')
+    print('     Forked from https://github.com/bishopdynamics/superbird-tool')
     print('')
     argument_parser = argparse.ArgumentParser(
         description='Options cannot be combined; do one thing at a time :)'
@@ -361,7 +362,9 @@ if __name__ == '__main__':
             dev.bulkcmd('env save')
             print('The device will now check for valid charger, requiring you to press menu button to bypass')
     elif args.burn_mode:
-        if check_device_mode('usb'):
+        if check_device_mode('usb-burn', silent=True):
+            print("Device already in USB Burn Mode")
+        elif check_device_mode('usb'):
             print('Entering USB Burn Mode')
             dev.bl2_boot(str(IMAGES_PATH.joinpath('superbird.bl2.encrypted.bin')), str(IMAGES_PATH.joinpath('superbird.bootloader.img')))
             print('Waiting for device...')


### PR DESCRIPTION
I adjusted the logic in the find_device function so --burn_mode stops outputting the 'Failed to enter USB Burn Mode!' error message when it does successfully boot the device into Burn Mode. Still not certain why it identifies as M8-CHIP. I also added a message for when the device is already in Burn Mode.

Lastly I made a few updates to the CLI attribution message and Changelog.md. I saved 0.1.1 and 0.1.2 for @lmore377's latest commits if they wanted to note changes and use those versions.

Please let me know if I need to change anything.

Added to Changelog.md:
* `--burn_mode`
  * Fixed --burn_mode bug causing false positive error message
  * Added message when using --burn_mode while in Burn Mode
* Housekeeping
  * Added 0.1.0 to Changelog
  * Updated CLI attribution message, added Car-Thing-Hax-Community name/repo link and specified using fork from bishopdynamics in cli output