### PR TITLE
ci: make standalone instead of onefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,12 @@ jobs:
           script-name: superbird_tool.py
           output-file: superbird-tool
           macos-target-arch: x86_64
-          onefile: true
+          onefile: false
+          standalone: true
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: superbird-tool ${{ runner.os }}
           path: |
-            build/superbird-tool.exe
-            build/superbird-tool
+            build/superbird_tool.dist/*


### PR DESCRIPTION
Building Python source to `.exe` is notorious for being an easy way to disguise malware, so most antivirus vendors have just outright flag everything built like that. Using nuitka with `--onefile` ([VirusTotal](https://www.virustotal.com/gui/file/c7ca3fc42e777a89c9f128e4689b766aa74551819da38678ad7960bd5cb393eb)) is detected by Windows Defender as malware, however using `--standalone` ([VirusTotal](https://www.virustotal.com/gui/file/05c7d01229dd0ea1ad614231051340c39843c1277da8b530ceb43d9fd765c5bc)) instead will output more files, but not be detected as malware (see that Microsoft does not detect it in VirusTotal).
For now all platforms get the new "standalone" build even though Windows is the only one blocking it, however there could be other antivirus software blocking it on other platforms as well.