### PR TITLE
ci: include images folder in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
           macos-target-arch: x86_64
           onefile: false
           standalone: true
+          include-data-files: images/*=images/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently commands like `--burn_mode` are failing in the executable builds, since it can't find the `images/` directory. Edited the build action so it includes that folder in the resulting folder.